### PR TITLE
solve small bug for SSexp2P and SSpower2P

### DIFF
--- a/R/SSexp2P.R
+++ b/R/SSexp2P.R
@@ -28,7 +28,7 @@ SSexp2P<-selfStart(
   {
     xy <- sortedXyData(mCall[["predictor"]],LHS, data)
 
-    if (min(y)>0){
+    if (min(xy[,"y"])>0){
     lmFit <- lm(log(xy[,"y"]) ~ xy[,"x"])
     coefs <- coef(lmFit)
     a <- exp(coefs[1])  #intercept

--- a/R/SSpower2P.R
+++ b/R/SSpower2P.R
@@ -28,7 +28,7 @@ SSpower2P<-selfStart(
 {
   xy <- sortedXyData(mCall[["predictor"]],LHS, data)
 
-  if (min(x)>0){
+  if (min(xy[,"x"])>0){
   lmFit <- lm(log(xy[,"y"]) ~ log(xy[,"x"])) # both x and adjy values should be greater than 0.
   coefs <- coef(lmFit)
   a <- exp(coefs[1])  #intercept


### PR DESCRIPTION
the x and y are not defined in local environment, so it results in so error reports. I used xy[, "x"] and xy[, "y"] to replace the x and y 